### PR TITLE
Do not check that CSV files are rectangles

### DIFF
--- a/gsheets/sheets.go
+++ b/gsheets/sheets.go
@@ -250,6 +250,7 @@ func (svc *Service) UpdateRangeStrings(id, a1Range string, values [][]string) (*
 // (so strings containing numerals may be converted to numbers, etc.)
 func (svc *Service) UpdateRangeCSV(id, a1Range string, values io.Reader) (*sheets.UpdateValuesResponse, error) {
 	csvR := csv.NewReader(values)
+	csvR.FieldsPerRecord = -1 // disable field checks
 	csvR.Comma = svc.Sep
 	rows, err := csvR.ReadAll()
 	if err != nil {


### PR DESCRIPTION
Hey :)

Sometimes we want to upload CSV files that are not perfect rectangles. Like, some lines have 10 fields, some have 7.

By default Go checks against that. This small commits changes this. I think it's not the role of your tool to check whether our CSV makes sense.

WDYT?

Have fun :) happy hacking, super useful tool.

Matcha