### PR TITLE
Add `WithService()` methods to gsheets, gdrive

### DIFF
--- a/gdrive/files.go
+++ b/gdrive/files.go
@@ -58,6 +58,10 @@ func NewServiceWithCtx(ctx context.Context) (*Service, error) {
 	}, nil
 }
 
+func (svc *Service) WithService(service *drive.Service) {
+	svc.filer = service.Files
+}
+
 // FilesService returns a pointer to the wrapped FilesService
 func (svc *Service) FilesService() *drive.FilesService {
 	return svc.filer.(*drive.FilesService)

--- a/gsheets/sheets.go
+++ b/gsheets/sheets.go
@@ -54,6 +54,11 @@ func NewServiceWithCtx(ctx context.Context) (*Service, error) {
 	}, nil
 }
 
+func (svc *Service) WithService(service *sheets.Service) {
+	svc.sheet = service.Spreadsheets
+	svc.values = service.Spreadsheets.Values
+}
+
 // SpreadsheetsService returns a pointer to the wrapped SpreadsheetsService
 func (svc *Service) SpreadsheetsService() *sheets.SpreadsheetsService {
 	return svc.sheet.(*sheets.SpreadsheetsService)


### PR DESCRIPTION
👋 LMK if you prefer a different mechanism for patches :)

This allows consumers of this (very nifty!) package to override the
service and provide their own (vs the default). Useful when using custom
options (ex specifying a credentials file or different transport).

An alternative would be to take the service as an argument to existing
constructor (breaking change, did not consider) or to add make the
internal interface public (not pursued since that interface is private
and I thought it odd to leak).

This change does **not** impact CLI usage and only expands the
functionality as a go package.
